### PR TITLE
Move resizing functionality to dedicated trait and class

### DIFF
--- a/modules/packager/src/main/scala/packager/windows/DefaultImageResizer.scala
+++ b/modules/packager/src/main/scala/packager/windows/DefaultImageResizer.scala
@@ -1,0 +1,83 @@
+package packager.windows
+
+import net.coobird.thumbnailator.Thumbnails
+import net.coobird.thumbnailator.filters.Canvas
+import net.coobird.thumbnailator.geometry.Positions
+import net.sf.image4j.codec.ico.ICOEncoder
+
+import java.awt.Color
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
+
+case object DefaultImageResizer extends ImageResizer {
+
+  def generateIcon(logoPath: os.Path, workDirPath: os.Path): os.Path = {
+    val icoTmpPath = workDirPath / "logo_tmp.ico"
+    val iconImage: BufferedImage = ImageIO.read(new File(logoPath.toString()));
+    ICOEncoder.write(iconImage, new File(icoTmpPath.toString()));
+    val icoPath = workDirPath / "logo.ico"
+    os.copy.over(icoTmpPath, icoPath)
+    icoPath
+  }
+
+  private def generateEmptyImage(width: Int, height: Int): BufferedImage =
+    new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+
+  private def resizeLogo(
+      logoPath: os.Path,
+      width: Int,
+      height: Int,
+      workDir: os.Path
+  ) = {
+    val resizedPath = workDir / "resized-logo.png"
+    Thumbnails
+      .of(logoPath.toString())
+      .size(width, height)
+      .toFile(new File(resizedPath.toString()))
+
+    resizedPath
+  }
+
+  def generateBanner(logoPath: os.Path, workDirPath: os.Path): os.Path = {
+    val emptyBanner = generateEmptyImage(493, 58)
+
+    val bannerPath = workDirPath / s"banner.bmp"
+    val resizedLogoPath = resizeLogo(logoPath, 55, 55, workDirPath)
+
+    Thumbnails
+      .of(emptyBanner)
+      .addFilter(new Canvas(493, 58, Positions.CENTER, Color.WHITE))
+      .size(493, 58)
+      .watermark(
+        Positions.CENTER_RIGHT,
+        ImageIO.read(new File(resizedLogoPath.toString())),
+        1
+      )
+      .toFile(new File(bannerPath.toString()));
+
+    bannerPath
+  }
+
+  def generateDialog(logoPath: os.Path, workDirPath: os.Path): os.Path = {
+
+    val emptyDialog = generateEmptyImage(493, 312)
+    val dialogPath = workDirPath / s"dialog.bmp"
+
+    val resizedLogoPath = resizeLogo(logoPath, 165, 330, workDirPath)
+
+    Thumbnails
+      .of(emptyDialog)
+      .size(493, 312)
+      .addFilter(new Canvas(493, 312, Positions.CENTER, Color.WHITE))
+      .watermark(
+        Positions.CENTER_LEFT,
+        ImageIO.read(new File(resizedLogoPath.toString())),
+        1
+      )
+      .toFile(new File(dialogPath.toString()));
+
+    dialogPath
+  }
+
+}

--- a/modules/packager/src/main/scala/packager/windows/ImageResizer.scala
+++ b/modules/packager/src/main/scala/packager/windows/ImageResizer.scala
@@ -1,0 +1,7 @@
+package packager.windows
+
+trait ImageResizer {
+  def generateIcon(logoPath: os.Path, workDirPath: os.Path): os.Path
+  def generateBanner(logoPath: os.Path, workDirPath: os.Path): os.Path
+  def generateDialog(logoPath: os.Path, workDirPath: os.Path): os.Path
+}

--- a/modules/packager/src/main/scala/packager/windows/WindowsUtils.scala
+++ b/modules/packager/src/main/scala/packager/windows/WindowsUtils.scala
@@ -1,15 +1,5 @@
 package packager.windows
 
-import net.coobird.thumbnailator.Thumbnails
-import net.coobird.thumbnailator.filters.Canvas
-import net.coobird.thumbnailator.geometry.Positions
-import net.sf.image4j.codec.ico.ICOEncoder
-
-import java.awt.Color
-import java.awt.image.BufferedImage
-import java.io.File
-import javax.imageio.ImageIO
-
 case object WindowsUtils {
 
   def convertLicenseToRtfFormat(licensePath: os.ReadablePath): String = {
@@ -21,74 +11,6 @@ case object WindowsUtils {
          |}
          |""".stripMargin
     rtfLicense
-  }
-
-  def generateIcon(logoPath: os.Path, workDirPath: os.Path): os.Path = {
-    val icoTmpPath = workDirPath / "logo_tmp.ico"
-    val iconImage: BufferedImage = ImageIO.read(new File(logoPath.toString()));
-    ICOEncoder.write(iconImage, new File(icoTmpPath.toString()));
-    val icoPath = workDirPath / "logo.ico"
-    os.copy.over(icoTmpPath, icoPath)
-    icoPath
-  }
-
-  private def generateEmptyImage(width: Int, height: Int): BufferedImage =
-    new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
-
-  private def resizeLogo(
-      logoPath: os.Path,
-      width: Int,
-      height: Int,
-      workDir: os.Path
-  ) = {
-    val resizedPath = workDir / "resized-logo.png"
-    Thumbnails
-      .of(logoPath.toString())
-      .size(width, height)
-      .toFile(new File(resizedPath.toString()))
-
-    resizedPath
-  }
-
-  def generateBanner(logoPath: os.Path, workDirPath: os.Path): os.Path = {
-    val emptyBanner = generateEmptyImage(493, 58)
-
-    val bannerPath = workDirPath / s"banner.bmp"
-    val resizedLogoPath = resizeLogo(logoPath, 55, 55, workDirPath)
-
-    Thumbnails
-      .of(emptyBanner)
-      .addFilter(new Canvas(493, 58, Positions.CENTER, Color.WHITE))
-      .size(493, 58)
-      .watermark(
-        Positions.CENTER_RIGHT,
-        ImageIO.read(new File(resizedLogoPath.toString())),
-        1
-      )
-      .toFile(new File(bannerPath.toString()));
-
-    bannerPath
-  }
-
-  def generateDialog(logoPath: os.Path, workDirPath: os.Path): os.Path = {
-
-    val emptyDialog = generateEmptyImage(493, 312)
-    val dialogPath = workDirPath / s"dialog.bmp"
-
-    val resizedLogoPath = resizeLogo(logoPath, 165, 330, workDirPath)
-
-    Thumbnails
-      .of(emptyDialog)
-      .size(493, 312)
-      .addFilter(new Canvas(493, 312, Positions.CENTER, Color.WHITE))
-      .watermark(
-        Positions.CENTER_LEFT,
-        ImageIO.read(new File(resizedLogoPath.toString())),
-        1
-      )
-      .toFile(new File(dialogPath.toString()));
-
-    dialogPath
   }
 
 }

--- a/modules/packager/src/test/scala/packager/windows/WixLogoSpec.scala
+++ b/modules/packager/src/test/scala/packager/windows/WixLogoSpec.scala
@@ -9,7 +9,7 @@ class WixLogoSpec extends munit.FunSuite {
   private lazy val logoPath: os.Path = TestUtils.logo(workDirPath)
 
   test("should prepare icon for wix installer") {
-    val iconPath = WindowsUtils.generateIcon(logoPath, workDirPath)
+    val iconPath = DefaultImageResizer.generateIcon(logoPath, workDirPath)
 
     val expectedIconPath = workDirPath / "logo.ico"
 
@@ -18,7 +18,7 @@ class WixLogoSpec extends munit.FunSuite {
   }
 
   test("should prepare banner for wix installer") {
-    val bannerPath = WindowsUtils.generateBanner(logoPath, workDirPath)
+    val bannerPath = DefaultImageResizer.generateBanner(logoPath, workDirPath)
 
     val expectedBannerPath = workDirPath / "banner.bmp"
 
@@ -28,7 +28,7 @@ class WixLogoSpec extends munit.FunSuite {
 
   test("should prepare dialog for wix installer") {
 
-    val dialogPath = WindowsUtils.generateDialog(logoPath, workDirPath)
+    val dialogPath = DefaultImageResizer.generateDialog(logoPath, workDirPath)
 
     val expectedDialogPath = workDirPath / "dialog.bmp"
 


### PR DESCRIPTION
So that users of the library can use a custom implementation, or just disable image resizing.

I've been having issues building a native-image of scala-cli on Windows, because of the use of `java.awt.*` classes by the libraries used to handle resizing. We should probably use a different implementation there (maybe by downloading and running a [portable ImageMagick](https://www.imagemagick.org/script/download.php#windows) archive).