### PR TITLE
Add option to disable WIX ICE validation

### DIFF
--- a/modules/cli/src/main/scala/packager/cli/commands/WindowsOptions.scala
+++ b/modules/cli/src/main/scala/packager/cli/commands/WindowsOptions.scala
@@ -14,7 +14,10 @@ final case class WindowsOptions(
     productName: String = "Scala packager",
     @Group("Windows")
     @HelpMessage("Text will be displayed on exit dialog")
-    exitDialog: Option[String] = None
+    exitDialog: Option[String] = None,
+    @Group("Windows")
+    @HelpMessage("Suppress Wix ICE validation (required for users that are neither interactive, not local administrators)")
+    suppressValidation: Boolean = false
 ) {
 
   def toWindowsSettings(
@@ -33,7 +36,8 @@ final case class WindowsOptions(
         os.pwd
       ),
       productName = productName,
-      exitDialog = exitDialog
+      exitDialog = exitDialog,
+      suppressValidation = suppressValidation
     )
 }
 

--- a/modules/packager/src/main/scala/packager/config/WindowsSettings.scala
+++ b/modules/packager/src/main/scala/packager/config/WindowsSettings.scala
@@ -5,5 +5,6 @@ case class WindowsSettings(
     maintainer: String,
     licencePath: os.ReadablePath,
     productName: String,
-    exitDialog: Option[String]
+    exitDialog: Option[String],
+    suppressValidation: Boolean
 ) extends BuildSettings

--- a/modules/packager/src/main/scala/packager/windows/WindowsPackage.scala
+++ b/modules/packager/src/main/scala/packager/windows/WindowsPackage.scala
@@ -54,6 +54,10 @@ case class WindowsPackage(
     val candleBinPath = os.Path(wixBin) / "bin" / "candle.exe"
     val lightBinPath = os.Path(wixBin) / "bin" / "light.exe"
 
+    val lightExtraArguments =
+      if (buildSettings.suppressValidation) Seq("-sval")
+      else Nil
+
     os.proc(
         candleBinPath,
         wixConfigPath,
@@ -68,7 +72,8 @@ case class WindowsPackage(
         "-o",
         outputPath,
         "-ext",
-        "WixUIExtension"
+        "WixUIExtension",
+        lightExtraArguments
       )
       .call(cwd = basePath)
 

--- a/modules/packager/src/test/scala/packager/windows/WindowsPackageTests.scala
+++ b/modules/packager/src/test/scala/packager/windows/WindowsPackageTests.scala
@@ -39,6 +39,7 @@ class WindowsPackageTests extends munit.FunSuite with PackageHelper {
       maintainer = "Scala Packager",
       licencePath = os.resource / "packager" / "apache-2.0",
       productName = "Scala packager product",
-      exitDialog = None
+      exitDialog = None,
+      suppressValidation = true
     )
 }


### PR DESCRIPTION
Seems it's a problem on Windows machines, from a non-interactive and non-local administrator user.