### PR TITLE
Don't use os.read buggy override

### DIFF
--- a/modules/cli/src/main/scala/packager/cli/commands/WindowsOptions.scala
+++ b/modules/cli/src/main/scala/packager/cli/commands/WindowsOptions.scala
@@ -7,6 +7,8 @@ import packager.config.{SharedSettings, WindowsSettings}
 
 import java.nio.charset.Charset
 
+import scala.io.Codec
+
 final case class WindowsOptions(
     @Group("Windows")
     @HelpMessage("Path to license file")
@@ -51,7 +53,7 @@ final case class WindowsOptions(
             extraConfig
               .map { path =>
                 val path0 = os.Path(path, os.pwd)
-                os.read(path0, charSet = Charset.defaultCharset(), offset = 0L)
+                os.read(path0, Codec(Charset.defaultCharset()))
               }
               .mkString(System.lineSeparator())
           }


### PR DESCRIPTION
This should fix `--extra-config` uses (added in https://github.com/VirtuslabRnD/scala-packager/pull/8).